### PR TITLE
Bump to go v1.26 and run go fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.26.0"
 
       -
         name: Run GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ "stable", "oldstable", "1.x" ]
+        go-version: [ "1.26.0" ]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 # Build stage
-FROM golang:alpine AS builder
+FROM golang:1.26.0-alpine3.23 AS builder
 WORKDIR /app
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
 COPY . .
-RUN go build -o baffo ./cmd/baffo/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o baffo ./cmd/baffo/main.go
 
 # Run stage
-FROM alpine:latest
+FROM scratch
 WORKDIR /app
-COPY --from=builder /app/baffo ./baffo
-COPY --from=builder /app/README.md ./README.md
+COPY --from=builder --chown=1000:1000 /app/baffo ./baffo
+COPY --from=builder --chown=1000:1000 /app/README.md ./README.md
+
+USER 1000:1000
 # Copy any other files needed at runtime here
 ENTRYPOINT ["/app/baffo"]

--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ The main highlight is the transpile command, which converts Logstash pipelines i
 You can try out the tool online at https://herrbez.github.io/baffo/. Simply paste your Logstash pipeline and
 see the conversion in action.
 
-For more advanced usage—such as converting multiple pipelines or integrating into your workflow—install baffo locally.
+For more advanced usage—such as converting multiple pipelines or integrating into your workflow—install baffo locally or use the docker image.
 
 
 ## Installation
 
 ```bash
 go install github.com/herrBez/baffo/cmd/baffo@latest
+```
+
+```bash
+docker run briomkez/baffo:latest
 ```
 
 
@@ -67,7 +71,7 @@ baffo transpile file.conf \
 > ⚠️ Disclaimer: Semantic equivalence between the input Logstash pipelines and the generated Elasticsearch ingest pipelines is not formally guaranteed. The output should not be used in production without careful review and testing.
 
 
-If you need a quick conversion without bothering creating a file you can:
+If you need a quick conversion without bothering creating a file you can execute:
 
 ```
 baffo transpile /dev/stdin --deal_with_error_locally=false \

--- a/ast/errors.go
+++ b/ast/errors.go
@@ -29,7 +29,7 @@ func NewNotFoundError(err error) error {
 
 // NotFoundErrorf formats according to a format specifier and returns the string
 // as a value that satisfies NotFounder.
-func NotFoundErrorf(format string, a ...interface{}) error {
+func NotFoundErrorf(format string, a ...any) error {
 	return NewNotFoundError(fmt.Errorf(format, a...))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/herrBez/baffo
 go 1.26
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.1
@@ -18,6 +17,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/herrBez/baffo
 
-go 1.24
+go 1.26
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/herrBez/baffo
 go 1.26
 
 require (
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.4.0
@@ -11,8 +10,6 @@ require (
 	github.com/spf13/viper v1.21.0
 	go.elastic.co/ecszerolog v0.2.0
 )
-
-require github.com/hashicorp/errwrap v1.1.0 // indirect
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,11 +12,6 @@ github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlnd
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/app/check/check.go
+++ b/internal/app/check/check.go
@@ -1,14 +1,13 @@
 package check
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+	"errors"
 
 	config "github.com/herrBez/baffo"
-	"github.com/herrBez/baffo/internal/format"
 )
 
 type Check struct{}
@@ -18,12 +17,12 @@ func New() Check {
 }
 
 func (f Check) Run(args []string) error {
-	var result *multierror.Error
+	var result error
 
 	for _, filename := range args {
 		stat, err := os.Stat(filename)
 		if err != nil {
-			result = multierror.Append(result, errors.Errorf("%s: %v", filename, err))
+			result = errors.Join(result, fmt.Errorf("%s: %v", filename, err))
 		}
 		if stat.IsDir() {
 			continue
@@ -33,16 +32,15 @@ func (f Check) Run(args []string) error {
 		if err != nil {
 			if errMsg, hasErr := config.GetFarthestFailure(); hasErr {
 				if !strings.Contains(err.Error(), errMsg) {
-					err = errors.Errorf("%s: %v\n%s", filename, err, errMsg)
+					err = fmt.Errorf("%s: %v\n%s", filename, err, errMsg)
 				}
 			}
-			result = multierror.Append(result, errors.Errorf("%s: %v", filename, err))
+			result = errors.Join(result, fmt.Errorf("%s: %v", filename, err))
 			continue
 		}
 	}
 
 	if result != nil {
-		result.ErrorFormat = format.MultiErr
 		return result
 	}
 

--- a/internal/app/ecs_check/ecs_check.go
+++ b/internal/app/ecs_check/ecs_check.go
@@ -54,7 +54,7 @@ func (f ECSCheck) Run(args []string) error {
 			// continue
 		} else {
 			var tree ast.Config = res.(ast.Config)
-			log.Println(reflect.TypeOf(tree))
+			log.Println(reflect.TypeFor[ast.Config]())
 
 			var input_plugin_names []string = getAllPluginNames(tree.Input)
 			var filter_plugin_names []string = getAllPluginNames(tree.Filter)

--- a/internal/app/ecs_check/ecs_check.go
+++ b/internal/app/ecs_check/ecs_check.go
@@ -1,6 +1,7 @@
 package ecs_check
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -8,13 +9,10 @@ import (
 	// "fmt"
 	"github.com/herrBez/baffo/ast/astutil"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
-
+	"errors"
 	"reflect"
 
 	config "github.com/herrBez/baffo"
-	"github.com/herrBez/baffo/internal/format"
 
 	ast "github.com/herrBez/baffo/ast"
 )
@@ -26,12 +24,11 @@ func New() ECSCheck {
 }
 
 func (f ECSCheck) Run(args []string) error {
-	var result *multierror.Error
-
+	var result error
 	for _, filename := range args {
 		stat, err := os.Stat(filename)
 		if err != nil {
-			result = multierror.Append(result, errors.Errorf("%s: %v", filename, err))
+			result = errors.Join(result, fmt.Errorf("%s: %v", filename, err))
 		}
 		if stat.IsDir() {
 			continue
@@ -47,10 +44,10 @@ func (f ECSCheck) Run(args []string) error {
 
 			// if errMsg, hasErr := config.GetFarthestFailure(); hasErr {
 			// 	if !strings.Contains(err.Error(), errMsg) {
-			// 		err = errors.Errorf("%s: %v\n%s", filename, err, errMsg)
+			// 		err = fmt.Errorf("%s: %v\n%s", filename, err, errMsg)
 			// 	}
 			// }
-			// result = multierror.Append(result, errors.Errorf("%s: %v", filename, err))
+			// result = errors.Join(result, fmt.Errorf("%s: %v", filename, err))
 			// continue
 		} else {
 			var tree ast.Config = res.(ast.Config)
@@ -69,7 +66,6 @@ func (f ECSCheck) Run(args []string) error {
 	}
 
 	if result != nil {
-		result.ErrorFormat = format.MultiErr
 		return result
 	}
 

--- a/internal/app/format/format.go
+++ b/internal/app/format/format.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	config "github.com/herrBez/baffo"
 	"github.com/herrBez/baffo/ast"
 )
@@ -28,7 +26,7 @@ func (f Format) Run(args []string) error {
 	for _, filename := range args {
 		stat, err := os.Stat(filename)
 		if err != nil {
-			return errors.Errorf("%s: %v", filename, err)
+			return fmt.Errorf("%s: %v", filename, err)
 		}
 		if stat.IsDir() {
 			continue
@@ -38,24 +36,24 @@ func (f Format) Run(args []string) error {
 		if err != nil {
 			if errMsg, hasErr := config.GetFarthestFailure(); hasErr {
 				if !strings.Contains(err.Error(), errMsg) {
-					return errors.Errorf("%s: %v\n%s", filename, err, errMsg)
+					return fmt.Errorf("%s: %v\n%s", filename, err, errMsg)
 				}
 			}
-			return errors.Errorf("%s: %v", filename, err)
+			return fmt.Errorf("%s: %v", filename, err)
 		}
 
 		if f.writeToSource {
 			err := func() error {
 				f, err := os.Create(filename)
 				if err != nil {
-					return errors.Wrap(err, "failed to open file for writting with automatically fixed ID")
+					return fmt.Errorf("failed to open file for writting with automatically fixed ID: %w", err)
 				}
 				defer f.Close()
 
 				conf := c.(ast.Config)
 				_, err = f.WriteString(conf.String())
 				if err != nil {
-					return errors.Wrap(err, "failed to write file with automatically fixed ID")
+					return fmt.Errorf("failed to write file with automatically fixed ID: %w", err)
 				}
 
 				return nil

--- a/internal/app/lint/lint.go
+++ b/internal/app/lint/lint.go
@@ -1,17 +1,14 @@
 package lint
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
-
 	config "github.com/herrBez/baffo"
 	"github.com/herrBez/baffo/ast"
 	"github.com/herrBez/baffo/ast/astutil"
-	"github.com/herrBez/baffo/internal/format"
 )
 
 type Lint struct {
@@ -25,12 +22,12 @@ func New(autoFixID bool) Lint {
 }
 
 func (l Lint) Run(args []string) error {
-	var result *multierror.Error
+	var result error
 
 	for _, filename := range args {
 		stat, err := os.Stat(filename)
 		if err != nil {
-			result = multierror.Append(result, errors.Errorf("%s: %v", filename, err))
+			result = errors.Join(result, fmt.Errorf("%s: %v", filename, err))
 		}
 		if stat.IsDir() {
 			continue
@@ -40,15 +37,15 @@ func (l Lint) Run(args []string) error {
 		if err != nil {
 			if errMsg, hasErr := config.GetFarthestFailure(); hasErr {
 				if !strings.Contains(err.Error(), errMsg) {
-					err = errors.Errorf("%s: %v\n%s", filename, err, errMsg)
+					err = fmt.Errorf("%s: %v\n%s", filename, err, errMsg)
 				}
 			}
-			result = multierror.Append(result, errors.Errorf("%s: %v", filename, err))
+			result = errors.Join(result, fmt.Errorf("%s: %v", filename, err))
 			continue
 		}
 		conf := c.(ast.Config)
 		for _, warning := range conf.Warnings {
-			result = multierror.Append(result, errors.New(warning))
+			result = errors.Join(result, errors.New(warning))
 		}
 
 		v := validator{
@@ -76,7 +73,7 @@ func (l Lint) Run(args []string) error {
 			for _, block := range v.noIDs {
 				errMsg.WriteString(block + "\n")
 			}
-			result = multierror.Append(result, errors.New(errMsg.String()))
+			result = errors.Join(result, errors.New(errMsg.String()))
 		}
 		if len(v.duplicateIDs) > 0 {
 			errMsg := strings.Builder{}
@@ -84,21 +81,21 @@ func (l Lint) Run(args []string) error {
 			for _, block := range v.duplicateIDs {
 				errMsg.WriteString(block + "\n")
 			}
-			result = multierror.Append(result, errors.New(errMsg.String()))
+			result = errors.Join(result, errors.New(errMsg.String()))
 		}
 
 		if l.autoFixID && v.changed {
 			func() {
 				f, err := os.Create(filename)
 				if err != nil {
-					result = multierror.Append(result, errors.Wrap(err, "failed to open file for writting with automatically fixed ID"))
+					result = errors.Join(result, errors.Join(err, errors.New("failed to open file for writting with automatically fixed ID")))
 					return
 				}
 				defer f.Close()
 
 				_, err = f.WriteString(conf.String())
 				if err != nil {
-					result = multierror.Append(result, errors.Wrap(err, "failed to write file with automatically fixed ID"))
+					result = errors.Join(result, errors.Join(err, errors.New("failed to write file with automatically fixed ID")))
 					return
 				}
 			}()
@@ -106,7 +103,6 @@ func (l Lint) Run(args []string) error {
 	}
 
 	if result != nil {
-		result.ErrorFormat = format.MultiErr
 		return result
 	}
 
@@ -131,9 +127,7 @@ func (v *validator) walk(c *astutil.Cursor) {
 			v.changed = true
 
 			plugin := c.Plugin()
-			// plugin.Attributes = append(plugin.Attributes, ast.NewStringAttribute("id", fmt.Sprintf("%s-%d", c.Plugin().Name(), v.count), ast.DoubleQuoted))
-
-			// plugin.Attributes = append(plugin.Attributes, ast.NewStringAttribute("id", fmt.Sprintf("%s", c.Plugin().Name()), ast.DoubleQuoted))
+			plugin.Attributes = append(plugin.Attributes, ast.NewStringAttribute("id", fmt.Sprintf("%s-%d", c.Plugin().Name(), v.count), ast.DoubleQuoted))
 
 			c.Replace(plugin)
 		} else {

--- a/internal/app/lint/lint.go
+++ b/internal/app/lint/lint.go
@@ -88,14 +88,14 @@ func (l Lint) Run(args []string) error {
 			func() {
 				f, err := os.Create(filename)
 				if err != nil {
-					result = errors.Join(result, errors.Join(err, errors.New("failed to open file for writting with automatically fixed ID")))
+					result = errors.Join(result, fmt.Errorf("failed to open file for writting with automatically fixed ID: %w", err))
 					return
 				}
 				defer f.Close()
 
 				_, err = f.WriteString(conf.String())
 				if err != nil {
-					result = errors.Join(result, errors.Join(err, errors.New("failed to write file with automatically fixed ID")))
+					result = errors.Join(result, fmt.Errorf("failed to write file with automatically fixed ID: %w", err))
 					return
 				}
 			}()

--- a/internal/app/transpile/logstash_filter.go
+++ b/internal/app/transpile/logstash_filter.go
@@ -43,9 +43,10 @@ func hashAttributeToMapArray(attr ast.Attribute) map[string][]string {
 
 func getBoolValue(attr ast.Attribute) bool {
 	rawString := getStringAttributeString(attr)
-	if rawString == "true" {
+	switch rawString {
+	case "true":
 		return true
-	} else if rawString == "false" {
+	case "false":
 		return false
 	}
 	log.Panic().Msg("Unexpected")

--- a/internal/app/transpile/logstash_filter.go
+++ b/internal/app/transpile/logstash_filter.go
@@ -52,9 +52,9 @@ func getBoolValue(attr ast.Attribute) bool {
 	return false
 }
 
-func getHashAttributeKeyValueUntyped(attr ast.Attribute) ([]string, []interface{}) {
+func getHashAttributeKeyValueUntyped(attr ast.Attribute) ([]string, []any) {
 	var keys []string
-	var values []interface{}
+	var values []any
 	switch t := attr.(type) {
 	case ast.HashAttribute:
 		for _, entry := range t.Entries {

--- a/internal/app/transpile/transpile.go
+++ b/internal/app/transpile/transpile.go
@@ -397,7 +397,7 @@ else {
 		keys, values := getHashAttributeKeyValue(attr)
 
 		for i := range keys {
-			if Contains([]string{"boolean", "integer_eu", "float_eu"}, values[i]) {
+			if slices.Contains([]string{"boolean", "integer_eu", "float_eu"}, values[i]) {
 				log.Warn().Msgf("Mutate Convert to type '%s' semantics may be different in Elasticsearch Convert Processor", values[i])
 			}
 			ingestProcessors = append(ingestProcessors, ConvertProcessor{
@@ -800,7 +800,7 @@ func DealWithCommonAttributes(plugin ast.Plugin) []IngestProcessor {
 	ingestProcessors := []IngestProcessor{}
 
 	for _, attr := range plugin.Attributes {
-		if !Contains(CommonAttributes, attr.Name()) {
+		if !slices.Contains(CommonAttributes, attr.Name()) {
 			continue // Ignore not common attributes
 		}
 		switch attr.Name() {
@@ -935,7 +935,7 @@ func DealWithDate(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor,
 	proc := DateProcessor{}.WithTag(id).(DateProcessor)
 
 	for _, attr := range plugin.Attributes {
-		if Contains(CommonAttributes, attr.Name()) {
+		if slices.Contains(CommonAttributes, attr.Name()) {
 			continue
 		}
 		switch attr.Name() {
@@ -1189,7 +1189,7 @@ func DealWithGrok(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor,
 	gp := GrokProcessor{}.WithTag(id).(GrokProcessor)
 
 	for _, attr := range plugin.Attributes {
-		if Contains(CommonAttributes, attr.Name()) {
+		if slices.Contains(CommonAttributes, attr.Name()) {
 			continue
 		}
 		switch attr.Name() {
@@ -1329,7 +1329,7 @@ func DealWithURLDecode(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 	udp := URLDecodeProcessor{}.WithTag(id).(URLDecodeProcessor)
 
 	for _, attr := range plugin.Attributes {
-		if Contains(CommonAttributes, attr.Name()) {
+		if slices.Contains(CommonAttributes, attr.Name()) {
 			continue
 		}
 		switch attr.Name() {
@@ -1600,7 +1600,7 @@ func (t Transpile) DealWithPlugin(section string, plugin ast.Plugin, constraint 
 	noncommonattrs := []ast.Attribute{}
 
 	for _, pa := range plugin.Attributes {
-		if !Contains(CommonAttributes, pa.Name()) {
+		if !slices.Contains(CommonAttributes, pa.Name()) {
 			noncommonattrs = append(noncommonattrs, pa)
 		}
 	}
@@ -1637,10 +1637,6 @@ func (t Transpile) DealWithPlugin(section string, plugin ast.Plugin, constraint 
 	return ingestProcessors
 }
 
-func Contains[T comparable](s []T, e T) bool {
-	return slices.Contains(s, e)
-}
-
 func getProcessorID(plugin ast.Plugin) string {
 	id, err := plugin.ID()
 	if err != nil {
@@ -1661,7 +1657,7 @@ func DealWithKV(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor, [
 	}.WithTag(id).(KVProcessor)
 
 	for _, attr := range plugin.Attributes {
-		if Contains(CommonAttributes, attr.Name()) {
+		if slices.Contains(CommonAttributes, attr.Name()) {
 			continue
 		}
 		switch attr.Name() {
@@ -1705,7 +1701,7 @@ func DealWithJSON(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor,
 	json := JSONProcessor{}.WithTag(id).(JSONProcessor)
 
 	for _, attr := range plugin.Attributes {
-		if Contains(CommonAttributes, attr.Name()) {
+		if slices.Contains(CommonAttributes, attr.Name()) {
 			continue
 		}
 		switch attr.Name() {

--- a/internal/app/transpile/transpile.go
+++ b/internal/app/transpile/transpile.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -73,7 +74,7 @@ func (t Transpile) Run(args []string) error {
 	var result *multierror.Error
 	ips := []IngestPipeline{}
 
-	var res interface{}
+	var res any
 	var err error
 
 	if t.inline {
@@ -199,23 +200,24 @@ func toElasticPipelineSelectorWithNullable(sel string, nullable bool) string {
 	// if the selector contains square brackets we need to convert them
 	if sel[0] == '[' && sel[len(sel)-1] == ']' {
 		parts := strings.Split(sel[1:len(sel)-1], "][")
-		elasticSelector := "ctx"
-		currentPath := ""
+		var elasticSelector strings.Builder
+		elasticSelector.WriteString("ctx")
+		var currentPath strings.Builder
 		for _, part := range parts {
 			// e.g., field metadata
 			if strings.HasPrefix(part, "@") {
-				elasticSelector += fmt.Sprintf(".getOrDefault('%s', null)", part)
-				currentPath += fmt.Sprintf("['%s']", part)
+				elasticSelector.WriteString(fmt.Sprintf(".getOrDefault('%s', null)", part))
+				currentPath.WriteString(fmt.Sprintf("['%s']", part))
 			} else {
-				elasticSelector += "?." + part
-				currentPath += fmt.Sprintf(".%s", part)
+				elasticSelector.WriteString("?." + part)
+				currentPath.WriteString(fmt.Sprintf(".%s", part))
 			}
 		}
 
 		if nullable {
-			return elasticSelector
+			return elasticSelector.String()
 		} else {
-			return "ctx" + currentPath
+			return "ctx" + currentPath.String()
 		}
 	} else {
 		if strings.Contains(sel, "@") || strings.Contains(sel, ".") {
@@ -375,7 +377,7 @@ func DealWithMutateAttributes(attr ast.Attribute, ingestProcessors []IngestProce
 		for _, value := range values {
 			field := toElasticPipelineSelector(value)
 			ingestProcessors = append(ingestProcessors, ScriptProcessor{
-				Source: pointer(
+				Source: new(
 					fmt.Sprintf(
 						`def fieldValue = $('%s', null);
 if(fieldValue instanceof String) {
@@ -387,7 +389,7 @@ if(fieldValue instanceof String) {
 else {
   throw new Exception("Cannot capitalize something that is not a string")
 }*/`, field, field, field)),
-			}.WithIf(pointer(getIfFieldDefined(field)), false).
+			}.WithIf(new(getIfFieldDefined(field)), false).
 				WithDescription(fmt.Sprintf("Capitalize field '%s'", field)))
 		}
 
@@ -516,7 +518,7 @@ else {
 				SetProcessor{
 					Value: values[i],
 					Field: keys[i],
-				}.WithIf(pointer(field_is_null), true).
+				}.WithIf(new(field_is_null), true).
 					WithDescription(fmt.Sprintf("Set field '%s' to value '%s' if null", keys[i], values[i])),
 			)
 		}
@@ -808,7 +810,7 @@ func DealWithCommonAttributes(plugin ast.Plugin) []IngestProcessor {
 
 			for i := range keys {
 
-				var value interface{}
+				var value any
 
 				switch values[i].(type) {
 				case string:
@@ -847,7 +849,7 @@ func DealWithCommonAttributes(plugin ast.Plugin) []IngestProcessor {
 			for _, t := range tags {
 				ingestProcessors = append(ingestProcessors,
 					ScriptProcessor{
-						Source: pointer(
+						Source: new(
 							fmt.Sprintf(
 								`if(ctx.tags instanceof List) {
 	ctx.tags.removeIf(x -> x == '%s')
@@ -891,7 +893,7 @@ func DealWithDrop(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor,
 				log.Info().Msgf("Percentage %d", value)
 				// TODO Add seed?
 				// TODO Make sure that random number is generated only on need
-				proc = proc.WithIf(pointer(fmt.Sprintf("new Random().nextInt(100) < %d", value)), true).(DropProcessor)
+				proc = proc.WithIf(new(fmt.Sprintf("new Random().nextInt(100) < %d", value)), true).(DropProcessor)
 			}
 		// Add if condition
 
@@ -941,13 +943,13 @@ func DealWithDate(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor,
 		case "tag_on_failure":
 			onFailureProcessors = DealWithTagOnFailure(attr, id, t)
 		case "target":
-			proc.TargetField = pointer(getStringAttributeString(attr))
+			proc.TargetField = new(getStringAttributeString(attr))
 		case "locale":
 			log.Warn().Msgf("Date filter is using %s %s. Please make sure it corresponds to Ingest Pipeline's one", attr.Name(), getStringAttributeString(attr))
-			proc.Locale = pointer(getStringAttributeString(attr))
+			proc.Locale = new(getStringAttributeString(attr))
 		case "timezone":
 			log.Warn().Msgf("Date filter is using %s %s. Please make sure it corresponds to Ingest Pipeline's one", attr.Name(), getStringAttributeString(attr))
-			proc.Timezone = pointer(getStringAttributeString(attr))
+			proc.Timezone = new(getStringAttributeString(attr))
 
 		case "match":
 			matchArray := getArrayStringAttributes(attr)
@@ -990,7 +992,7 @@ func DealWithGeoIP(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor
 			gp.Field = toElasticPipelineSelector(getStringAttributeString(attr))
 
 		case "target":
-			gp.TargetField = pointer(toElasticPipelineSelector(getStringAttributeString(attr)))
+			gp.TargetField = new(toElasticPipelineSelector(getStringAttributeString(attr)))
 
 		case "tag_on_failure":
 			onFailurePorcessors = DealWithTagOnFailure(attr, id, t)
@@ -1025,12 +1027,12 @@ func DealWithGeoIP(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor
 		if len(asn_properties) > 0 {
 			gp_asn := GeoIPProcessor{
 				Field:        gp.Field,
-				DatabaseFile: pointer("GeoLite2-ASN.mmdb"),
+				DatabaseFile: new("GeoLite2-ASN.mmdb"),
 				Properties:   &asn_properties,
 			}.WithTag(gp.GetTagOrDefault("") + "asn").(GeoIPProcessor)
 
 			if gp.TargetField != nil {
-				gp_asn.TargetField = pointer(*gp.TargetField + ".as")
+				gp_asn.TargetField = new(*gp.TargetField + ".as")
 			}
 			ingestProcessors = append(ingestProcessors, gp_asn)
 		}
@@ -1040,7 +1042,7 @@ func DealWithGeoIP(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor
 				Properties: &other_properties,
 			}.WithTag(id).(GeoIPProcessor)
 			if gp.TargetField != nil {
-				gp_other.TargetField = pointer(*gp.TargetField + ".geo")
+				gp_other.TargetField = new(*gp.TargetField + ".geo")
 			}
 			ingestProcessors = append(ingestProcessors, gp_other)
 		}
@@ -1071,13 +1073,13 @@ func DealWithUserAgent(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 			`)
 
 		case "regexes":
-			uap.RegexFile = pointer(getStringAttributeString(attr))
+			uap.RegexFile = new(getStringAttributeString(attr))
 
 		case "source":
 			uap.Field = toElasticPipelineSelector(getStringAttributeString(attr))
 
 		case "target":
-			uap.TargetField = pointer(toElasticPipelineSelector(getStringAttributeString(attr)))
+			uap.TargetField = new(toElasticPipelineSelector(getStringAttributeString(attr)))
 
 		default:
 			log.Warn().Msgf("Attribute '%s' in Plugin '%s' is currently not supported", attr.Name(), plugin.Name())
@@ -1091,7 +1093,7 @@ func DealWithUserAgent(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 		case "disabled":
 			// An empty field is not supported by Elasticsearch
 			// TODO --> Add an on-success processor to copy the original field in the root of the document
-			uap.TargetField = pointer("")
+			uap.TargetField = new("")
 		case "v8", "v1":
 			log.Debug().Msg("Nothing to do since the UserAgent Processor already uses user_agent as target field")
 		}
@@ -1135,7 +1137,7 @@ func DealWithUserAgent(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 			Field: &field,
 		}.
 			WithTag(id+"-remove-"+prefix+"-os").
-			WithIf(pointer(getIfFieldIsDefinedAndEmpty(prefix+"os")), true),
+			WithIf(new(getIfFieldIsDefinedAndEmpty(prefix+"os")), true),
 		)
 
 		// Rename the device.name to device (to do so you need first to copy it and remove it)
@@ -1395,7 +1397,7 @@ func DealWithCidr(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor,
 		elastic_addresses = append(elastic_addresses, transformed_address)
 	}
 
-	params := make(map[string]interface{})
+	params := make(map[string]any)
 	params["networks"] = networks
 
 	addressOutput := ""
@@ -1428,7 +1430,7 @@ throw new Exception('Could not find CIDR value');`, addressOutput))
 	}
 
 	ingestProcessors = append(ingestProcessors, ScriptProcessor{
-		Source: pointer(b.String()),
+		Source: new(b.String()),
 		Params: &params,
 	}.WithTag(id))
 
@@ -1469,7 +1471,7 @@ func DealWithSyslogPri(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 		case "ecs_compatibility":
 			ECSCompatibility = getStringAttributeString(attr)
 		case "syslog_pri_field_name":
-			field = pointer(getStringAttributeString(attr))
+			field = new(getStringAttributeString(attr))
 		case "severity_labels":
 			severityLabels = getArrayStringAttributes(attr)
 		case "facility_labels":
@@ -1482,9 +1484,9 @@ func DealWithSyslogPri(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 	if field == nil {
 		switch ECSCompatibility {
 		case "disabled":
-			field = pointer("syslog_pri")
+			field = new("syslog_pri")
 		case "v1", "v8":
-			field = pointer("log.syslog.priority")
+			field = new("log.syslog.priority")
 		}
 	}
 
@@ -1524,13 +1526,13 @@ field('log.syslog.facility.code').set(facility);
 
 	if useLabels {
 		log.Debug().Msgf("UseLabels True")
-		params := make(map[string]interface{})
+		params := make(map[string]any)
 		params["facility"] = facilityLabels
 		params["severity"] = severityLabels
 		setValuesString = fmt.Sprintf("%s\n%s", setValuesString, useLabelsScript)
 		proc.Params = &params
 	}
-	proc.Source = pointer(fmt.Sprintf("%s\n%s", extractValue, setValuesString))
+	proc.Source = new(fmt.Sprintf("%s\n%s", extractValue, setValuesString))
 
 	ingestProcessors = append(ingestProcessors, proc)
 	return ingestProcessors, onFailureProcessor
@@ -1578,7 +1580,7 @@ func (t Transpile) DealWithPlugin(section string, plugin ast.Plugin, constraint 
 
 	constraintTranspiled := transpileConstraint(constraint)
 
-	onSuccessCondition := pointer(fmt.Sprintf("!(%s)", getIfFieldDefined(getUniqueOnFailureAddField(id))))
+	onSuccessCondition := new(fmt.Sprintf("!(%s)", getIfFieldDefined(getUniqueOnFailureAddField(id))))
 	onSuccessProcessors := DealWithCommonAttributes(plugin)
 	for i := range onSuccessProcessors {
 		// log.Info().Msgf("[%d] = %s %s", i, constraintTranspiled, onSuccessCondition)
@@ -1636,12 +1638,7 @@ func (t Transpile) DealWithPlugin(section string, plugin ast.Plugin, constraint 
 }
 
 func Contains[T comparable](s []T, e T) bool {
-	for _, v := range s {
-		if v == e {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s, e)
 }
 
 func getProcessorID(plugin ast.Plugin) string {
@@ -1672,9 +1669,9 @@ func DealWithKV(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor, [
 		case "tag_on_failure":
 			onFailureProcessors = DealWithTagOnFailure(attr, id, t)
 		case "target":
-			kv.TargetField = pointer(getStringAttributeString(attr))
+			kv.TargetField = new(getStringAttributeString(attr))
 		case "prefix":
-			kv.Prefix = pointer(getStringAttributeString(attr))
+			kv.Prefix = new(getStringAttributeString(attr))
 		case "field_split":
 			kv.FieldSplit = getStringAttributeString(attr) // TODO: De-Escape chars???
 		case "exclude_keys":
@@ -1737,7 +1734,7 @@ func DealWithDissect(plugin ast.Plugin, id string, t Transpile) ([]IngestProcess
 
 	proc := DissectProcessor{
 		// Dissect in Logstash always add a space in the appended information
-		AppendSeparator: pointer(" "),
+		AppendSeparator: new(" "),
 	}.WithTag(id).(DissectProcessor)
 
 	for _, attr := range plugin.Attributes {
@@ -1868,7 +1865,7 @@ func DealWithCSV(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor, 
 
 	onSuccessProcessors := []IngestProcessor{}
 
-	proc := CSVProcessor{Field: "message", EmptyValue: pointer("")}.WithTag(id).(CSVProcessor)
+	proc := CSVProcessor{Field: "message", EmptyValue: new("")}.WithTag(id).(CSVProcessor)
 
 	prefix := ""
 
@@ -1884,9 +1881,9 @@ func DealWithCSV(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor, 
 		case "autodetect_column_names":
 			autodetect_column_names = getBoolValue(attr)
 		case "separator":
-			proc.Separator = pointer(getStringAttributeString(attr))
+			proc.Separator = new(getStringAttributeString(attr))
 		case "quote_char":
-			proc.Quote = pointer(getStringAttributeString(attr))
+			proc.Quote = new(getStringAttributeString(attr))
 
 		// Deal with skip_empty_columns explicitely set
 		case "skip_empty_columns":
@@ -1894,7 +1891,7 @@ func DealWithCSV(plugin ast.Plugin, id string, t Transpile) ([]IngestProcessor, 
 			if skip_empty_columns {
 				proc.EmptyValue = nil
 			} else {
-				proc.EmptyValue = pointer("")
+				proc.EmptyValue = new("")
 			}
 		case "convert":
 			keys, values := getHashAttributeKeyValue(attr)
@@ -1942,7 +1939,7 @@ func DealWithTranslate(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 
 	proc := ScriptProcessor{}.WithTag(id).(ScriptProcessor)
 
-	params := make(map[string]interface{})
+	params := make(map[string]any)
 
 	var target *string = nil
 	ECSCompatibility := "v8" // We assume ECS Compatibility
@@ -1955,7 +1952,7 @@ func DealWithTranslate(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 		case "tag_on_failure":
 			onFailureProcessors = DealWithTagOnFailure(attr, id, t)
 		case "destination", "target":
-			target = pointer(getStringAttributeString(attr))
+			target = new(getStringAttributeString(attr))
 
 		case "dictionary":
 
@@ -1969,7 +1966,7 @@ func DealWithTranslate(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 			ECSCompatibility = getStringAttributeString(attr)
 
 		case "field", "source":
-			source = pointer(getStringAttributeString(attr))
+			source = new(getStringAttributeString(attr))
 
 		case "fallback":
 			params["fallback"] = getStringAttributeString(attr)
@@ -1983,7 +1980,7 @@ func DealWithTranslate(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 	if target == nil {
 		switch ECSCompatibility {
 		case "disabled":
-			target = pointer("translation")
+			target = new("translation")
 		case "v1", "v8":
 			target = source
 		}
@@ -2005,9 +2002,9 @@ func DealWithTranslate(plugin ast.Plugin, id string, t Transpile) ([]IngestProce
 
 	b.WriteString(fmt.Sprintf(`if (tmp != null) { field('%s').set(tmp); }`, field))
 
-	proc.Source = pointer(b.String())
+	proc.Source = new(b.String())
 
-	proc.Description = pointer(fmt.Sprintf("Translate the field '%s' to field '%s'.", toElasticPipelineSelector(*source), toElasticPipelineSelector(*target)))
+	proc.Description = new(fmt.Sprintf("Translate the field '%s' to field '%s'.", toElasticPipelineSelector(*source), toElasticPipelineSelector(*target)))
 
 	ingestProcessors = append(ingestProcessors, proc)
 
@@ -2031,7 +2028,7 @@ func transpileConstraint(constraint Constraints) *string {
 		return nil
 	}
 	if len(constraint.Conditions) == 1 {
-		return pointer(transpileCondition(constraint.Conditions[0]))
+		return new(transpileCondition(constraint.Conditions[0]))
 	}
 	converted := "("
 	for i, cond := range constraint.Conditions {
@@ -2114,7 +2111,7 @@ func (t Transpile) buildIngestPipeline(filename string, c ast.Config) []IngestPi
 
 	if t.addCleanUpProcessor {
 		ip.Processors = append(ip.Processors, RemoveProcessor{
-			Field:         pointer([]string{TRANSPILER_PREFIX, "@metadata"}),
+			Field:         new([]string{TRANSPILER_PREFIX, "@metadata"}),
 			IgnoreMissing: true,
 		}.WithTag("cleanup-metadata").WithDescription("Cleanup temporary fields created by the transpiler"))
 	}
@@ -2129,14 +2126,14 @@ func (t Transpile) buildIngestPipeline(filename string, c ast.Config) []IngestPi
 
 func printPipeline(ips []IngestPipeline) {
 	// 1. Create a map to represent the top-level JSON object
-	data := make(map[string]interface{})
+	data := make(map[string]any)
 
 	// 2. Populate the map with pipeline data
 	for _, pipeline := range ips {
 		// Assuming pipeline.String() returns a valid JSON string (even if multi-line).
 		// We'll unmarshal that inner JSON first so we can put the actual data
 		// (not the string representation) into the top-level map.
-		var pipelineData interface{}
+		var pipelineData any
 		err := json.Unmarshal([]byte(pipeline.String()), &pipelineData)
 		if err != nil {
 			// Handle error if inner pipeline string isn't valid JSON

--- a/internal/app/transpile/transpile.go
+++ b/internal/app/transpile/transpile.go
@@ -18,13 +18,11 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+	"errors"
 
 	"reflect"
 
 	config "github.com/herrBez/baffo"
-	"github.com/herrBez/baffo/internal/format"
 
 	ast "github.com/herrBez/baffo/ast"
 
@@ -71,7 +69,7 @@ func (t Transpile) Run(args []string) error {
 	log.Logger = logger
 	zerolog.SetGlobalLevel(t.log_level)
 
-	var result *multierror.Error
+	var result error
 	ips := []IngestPipeline{}
 
 	var res any
@@ -87,7 +85,7 @@ func (t Transpile) Run(args []string) error {
 		res, err = config.Parse(filename, content, config.IgnoreComments(true))
 		if err != nil {
 			log.Warn().Msgf("%s %s %s", err, res, reflect.TypeOf(res))
-			// result = multierror.Append(result, errors.Errorf("%s: %v", filename, err))
+			// result = errors.Join(result, errors.Errorf("%s: %v", filename, err))
 			return err
 		} else {
 			var tree ast.Config = res.(ast.Config)
@@ -100,7 +98,7 @@ func (t Transpile) Run(args []string) error {
 		for _, filename := range args {
 			stat, err := os.Stat(filename)
 			if err != nil {
-				result = multierror.Append(result, errors.Errorf("%s: %v", filename, err))
+				result = errors.Join(result, fmt.Errorf("%s: %v", filename, err))
 				continue
 			}
 			if stat.IsDir() {
@@ -109,7 +107,7 @@ func (t Transpile) Run(args []string) error {
 			res, err = config.ParseFile(filename, config.IgnoreComments(true))
 			if err != nil {
 				log.Warn().Msgf("%s %s %s", err, res, reflect.TypeOf(res))
-				// result = multierror.Append(result, errors.Errorf("%s: %v", filename, err))
+				// result = errors.Join(result, errors.Errorf("%s: %v", filename, err))
 				continue
 			} else {
 				var tree ast.Config = res.(ast.Config)
@@ -123,7 +121,6 @@ func (t Transpile) Run(args []string) error {
 	printPipeline(ips)
 
 	if result != nil {
-		result.ErrorFormat = format.MultiErr
 		return result
 	}
 

--- a/internal/app/transpile/transpile_apply.go
+++ b/internal/app/transpile/transpile_apply.go
@@ -108,7 +108,7 @@ func (t Transpile) MyIteration(root []ast.BranchOrPlugin, constraint Constraints
 			if !t.fidelity {
 				cond = transpileConstraint(currentConstraints)
 			} else {
-				cond = pointer(fmt.Sprintf("ctx.%s['%s-if']", TRANSPILER_PREFIX, branchName))
+				cond = new(fmt.Sprintf("ctx.%s['%s-if']", TRANSPILER_PREFIX, branchName))
 			}
 
 			// mergeWithIP(ip, tmp_ip, currentConstraints, t.threshold)
@@ -134,7 +134,7 @@ func (t Transpile) MyIteration(root []ast.BranchOrPlugin, constraint Constraints
 				if !t.fidelity {
 					cond = transpileConstraint(currentConstraints)
 				} else {
-					cond = pointer(fmt.Sprintf("ctx.%s['%s-elseif-%d']", TRANSPILER_PREFIX, branchName, i))
+					cond = new(fmt.Sprintf("ctx.%s['%s-elseif-%d']", TRANSPILER_PREFIX, branchName, i))
 				}
 
 				t.mergeWithIPFidelity(ip, tmp_ip, cond)
@@ -151,7 +151,7 @@ func (t Transpile) MyIteration(root []ast.BranchOrPlugin, constraint Constraints
 			if !t.fidelity {
 				cond = transpileConstraint(currentConstraints)
 			} else {
-				cond = pointer(fmt.Sprintf("ctx.%s['%s-else']", TRANSPILER_PREFIX, branchName))
+				cond = new(fmt.Sprintf("ctx.%s['%s-else']", TRANSPILER_PREFIX, branchName))
 			}
 			// mergeWithIP(ip, tmp_ip, currentConstraints, t.threshold)
 			t.mergeWithIPFidelity(ip, tmp_ip, cond)

--- a/internal/app/transpile/transpile_helper.go
+++ b/internal/app/transpile/transpile_helper.go
@@ -94,14 +94,14 @@ func AppendIf(origIf *string, newIf *string) *string {
 	} else if newIf == nil {
 		resIf = origIf
 	} else {
-		resIf = pointer(fmt.Sprintf("(%s) && (%s)", *newIf, *origIf))
+		resIf = new(fmt.Sprintf("(%s) && (%s)", *newIf, *origIf))
 	}
 	return resIf
 }
 
 func (ingestPipeline IngestPipeline) String() string {
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"description": ingestPipeline.Description,
 		"processors":  ingestPipeline.Processors,
 	}
@@ -184,13 +184,13 @@ func (cf CommonFields) GetDescriptionOrDefault(str string) string {
 }
 
 type SetProcessor struct {
-	Value            interface{} `json:"value,omitempty"`
-	Field            string      `json:"field"`
-	CopyFrom         string      `json:"copy_from,omitempty"`
-	Override         bool        `json:"override,omitempty"`
-	IgnoreEmptyValue bool        `json:"ignore_empty_value,omitempty"`
-	MediaType        string      `json:"media_type,omitempty"`
-	IgnoreFailure    bool        `json:"ignore_failure,omitempty"`
+	Value            any    `json:"value,omitempty"`
+	Field            string `json:"field"`
+	CopyFrom         string `json:"copy_from,omitempty"`
+	Override         bool   `json:"override,omitempty"`
+	IgnoreEmptyValue bool   `json:"ignore_empty_value,omitempty"`
+	MediaType        string `json:"media_type,omitempty"`
+	IgnoreFailure    bool   `json:"ignore_failure,omitempty"`
 	CommonFields
 }
 
@@ -205,7 +205,7 @@ func (ip SetProcessor) MarshalJSON() ([]byte, error) {
 
 func StringHelper(ip IngestProcessor) string {
 
-	return ExtractString(MyJsonEncode(map[string]interface{}{
+	return ExtractString(MyJsonEncode(map[string]any{
 		ip.IngestProcessorType(): ip,
 	}))
 }
@@ -233,12 +233,12 @@ func (sp SetProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp SetProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp SetProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -273,12 +273,12 @@ func (sp RemoveProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp RemoveProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp RemoveProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -323,12 +323,12 @@ func (sp RenameProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp RenameProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp RenameProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -360,8 +360,8 @@ func (cp CaseProcessor) IngestProcessorType() string {
 	return cp.Type
 }
 
-func (sp CaseProcessor) ToOutputMap() map[string]interface{} {
-	return map[string]interface{}{}
+func (sp CaseProcessor) ToOutputMap() map[string]any {
+	return map[string]any{}
 }
 
 func (sp CaseProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
@@ -379,12 +379,12 @@ func (sp CaseProcessor) WithIf(s *string, append bool) IngestProcessor {
 }
 
 func (sp CaseProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp CaseProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -424,12 +424,12 @@ func (sp GrokProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp GrokProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp GrokProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -494,12 +494,12 @@ func (sp AppendProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp AppendProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp AppendProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -536,12 +536,12 @@ func (sp GsubProcessor) WithIf(s *string, append bool) IngestProcessor {
 }
 
 func (sp GsubProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp GsubProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -597,12 +597,12 @@ func (ip JoinProcessor) MarshalJSON() ([]byte, error) {
 }
 
 func (sp JoinProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp JoinProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -656,12 +656,12 @@ func (ip KVProcessor) MarshalJSON() ([]byte, error) {
 }
 
 func (sp KVProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp KVProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -707,12 +707,12 @@ func (ip DissectProcessor) MarshalJSON() ([]byte, error) {
 }
 
 func (sp DissectProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp DissectProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -747,12 +747,12 @@ func (sp DateProcessor) WithIf(s *string, append bool) IngestProcessor {
 }
 
 func (sp DateProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp DateProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -809,12 +809,12 @@ func (sp DropProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp DropProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp DropProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -861,12 +861,12 @@ func (ip SplitProcessor) MarshalJSON() ([]byte, error) {
 }
 
 func (sp SplitProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp SplitProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -902,12 +902,12 @@ func (sp TrimProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp TrimProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp TrimProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -951,12 +951,12 @@ func (sp PipelineProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp PipelineProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp PipelineProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -968,11 +968,11 @@ func (ip PipelineProcessor) MarshalJSON() ([]byte, error) {
 }
 
 type ScriptProcessor struct {
-	Lang          *string                 `json:"lang,omitempty"`
-	Id            *string                 `json:"id,omitempty"`
-	Source        *string                 `json:"source,omitempty"`
-	Params        *map[string]interface{} `json:"params,omitempty"`
-	IgnoreFailure bool                    `json:"ignore_failure,omitempty"`
+	Lang          *string         `json:"lang,omitempty"`
+	Id            *string         `json:"id,omitempty"`
+	Source        *string         `json:"source,omitempty"`
+	Params        *map[string]any `json:"params,omitempty"`
+	IgnoreFailure bool            `json:"ignore_failure,omitempty"`
 	CommonFields
 }
 
@@ -999,12 +999,12 @@ func (sp ScriptProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp ScriptProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp ScriptProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -1056,12 +1056,12 @@ func (sp ConvertProcessor) WithIf(s *string, append bool) IngestProcessor {
 }
 
 func (sp ConvertProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp ConvertProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -1110,12 +1110,12 @@ func (sp GeoIPProcessor) IngestProcessorType() string {
 }
 
 func (sp GeoIPProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp GeoIPProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -1172,12 +1172,12 @@ func (sp UserAgentProcessor) WithIf(s *string, append bool) IngestProcessor {
 }
 
 func (sp UserAgentProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp UserAgentProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -1227,12 +1227,12 @@ func (sp URLDecodeProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor 
 }
 
 func (sp URLDecodeProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp URLDecodeProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -1286,12 +1286,12 @@ func (sp CSVProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp CSVProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp CSVProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }
 
@@ -1340,11 +1340,11 @@ func (sp JSONProcessor) WithOnFailure(s []IngestProcessor) IngestProcessor {
 }
 
 func (sp JSONProcessor) WithTag(tag string) IngestProcessor {
-	sp.Tag = pointer(tag)
+	sp.Tag = new(tag)
 	return sp
 }
 
 func (sp JSONProcessor) WithDescription(description string) IngestProcessor {
-	sp.Description = pointer(description)
+	sp.Description = new(description)
 	return sp
 }

--- a/internal/app/transpile/transpile_test.go
+++ b/internal/app/transpile/transpile_test.go
@@ -152,7 +152,7 @@ func TestToElasticPipelineSelector(t *testing.T) {
 }
 
 // Help function to guarantee that a function returning a value and an error, returns only the value
-func dealWithError(i interface{}, err error) interface{} {
+func dealWithError(i any, err error) any {
 	if err == nil {
 		return i
 	}
@@ -165,7 +165,7 @@ func dealWithError(i interface{}, err error) interface{} {
 // 2. Parse the dummy configuration
 // 3. Extract the condition
 func extractCondition(s string) ast.Condition {
-	return dealWithError(config.Parse("fake", []byte(fmt.Sprintf("filter { if %s {} }", s)))).(ast.Config).Filter[0].BranchOrPlugins[0].(ast.Branch).IfBlock.Condition
+	return dealWithError(config.Parse("fake", fmt.Appendf(nil, "filter { if %s {} }", s))).(ast.Config).Filter[0].BranchOrPlugins[0].(ast.Branch).IfBlock.Condition
 }
 
 func TestEndToEnd(t *testing.T) {

--- a/internal/app/transpile/utils.go
+++ b/internal/app/transpile/utils.go
@@ -1,5 +1,0 @@
-package transpile
-
-func pointer[T any](d T) *T {
-	return &d
-}

--- a/logstash_config_helper.go
+++ b/logstash_config_helper.go
@@ -13,7 +13,7 @@ import (
 
 type exceptionalCommentsWarnings []string
 
-func (w exceptionalCommentsWarnings) Clone() interface{} {
+func (w exceptionalCommentsWarnings) Clone() any {
 	clone := make(exceptionalCommentsWarnings, 0, len(w))
 	clone = append(clone, w...)
 	return clone
@@ -32,11 +32,11 @@ func (c *current) initParser() (bool, error) {
 	return true, nil
 }
 
-func (c *current) ret(el interface{}) (interface{}, error) {
+func (c *current) ret(el any) (any, error) {
 	return el, nil
 }
 
-func (c *current) retConfig(el interface{}) (interface{}, error) {
+func (c *current) retConfig(el any) (any, error) {
 	conf, _ := el.(ast.Config)
 
 	warnings, _ := c.state[exceptionalCommentWarning].(exceptionalCommentsWarnings)
@@ -45,7 +45,7 @@ func (c *current) retConfig(el interface{}) (interface{}, error) {
 	return conf, nil
 }
 
-func (c *current) commentBlock(comment1 interface{}, spaceBefore bool, spaceAfter bool) ast.CommentBlock {
+func (c *current) commentBlock(comment1 any, spaceBefore bool, spaceAfter bool) ast.CommentBlock {
 	comments1 := toIfaceSlice(comment1)
 	var comments []ast.Comment
 	for _, icb1 := range comments1 {
@@ -68,7 +68,7 @@ func (c *current) commentBlock(comment1 interface{}, spaceBefore bool, spaceAfte
 	return comments
 }
 
-func (c *current) configSection(ps1, psComment1 interface{}) (ast.PluginSection, error) {
+func (c *current) configSection(ps1, psComment1 any) (ast.PluginSection, error) {
 	ps, ok := ps1.(ast.PluginSection)
 	if !ok {
 		return ast.PluginSection{}, fmt.Errorf("Value is not a PluginSection: %#v", ps1)
@@ -81,7 +81,7 @@ func (c *current) configSection(ps1, psComment1 interface{}) (ast.PluginSection,
 	return ps, nil
 }
 
-func (c *current) config(ps1, pss1, psComment1, footerComment1 interface{}) (ast.Config, error) {
+func (c *current) config(ps1, pss1, psComment1, footerComment1 any) (ast.Config, error) {
 	var (
 		input  []ast.PluginSection
 		filter []ast.PluginSection
@@ -167,7 +167,7 @@ func (c *current) comment() ([]ast.Comment, error) {
 	return commentLines, nil
 }
 
-func (c *current) pluginSection(pt1, bops1, footerComment1 interface{}) (ast.PluginSection, error) {
+func (c *current) pluginSection(pt1, bops1, footerComment1 any) (ast.PluginSection, error) {
 	pt := ast.PluginType(pt1.(int))
 	ibops := toIfaceSlice(bops1)
 	var bops []ast.BranchOrPlugin
@@ -185,7 +185,7 @@ func (c *current) pluginSection(pt1, bops1, footerComment1 interface{}) (ast.Plu
 	}, nil
 }
 
-func (c *current) plugin(name1, attributes1, comment1, footerComment1 interface{}) (ast.Plugin, error) {
+func (c *current) plugin(name1, attributes1, comment1, footerComment1 any) (ast.Plugin, error) {
 	var attributes []ast.Attribute
 	if attributes1 != nil {
 		attributes = attributes1.([]ast.Attribute)
@@ -200,7 +200,7 @@ func (c *current) plugin(name1, attributes1, comment1, footerComment1 interface{
 	return p, nil
 }
 
-func (c *current) attributes(attribute1, attributes1, comment1 interface{}) ([]ast.Attribute, error) {
+func (c *current) attributes(attribute1, attributes1, comment1 any) ([]ast.Attribute, error) {
 	attribute, _ := c.attributeComment(attribute1, comment1, false)
 	iattributes := toIfaceSlice(attribute)
 	iattributes = append(iattributes, toIfaceSlice(attributes1)...)
@@ -218,7 +218,7 @@ func (c *current) attributes(attribute1, attributes1, comment1 interface{}) ([]a
 	return attributes, nil
 }
 
-func (c *current) attributeComment(attribute1, comment1 interface{}, spaceBefore bool) (ast.Attribute, error) {
+func (c *current) attributeComment(attribute1, comment1 any, spaceBefore bool) (ast.Attribute, error) {
 	var attribute ast.Attribute
 	switch attr := attribute1.(type) {
 	case ast.StringAttribute:
@@ -242,7 +242,7 @@ func (c *current) attributeComment(attribute1, comment1 interface{}, spaceBefore
 	return attribute, nil
 }
 
-func (c *current) attribute(name, value interface{}) (ast.Attribute, error) {
+func (c *current) attribute(name, value any) (ast.Attribute, error) {
 	var key ast.StringAttribute
 
 	switch name := name.(type) {
@@ -310,7 +310,7 @@ func (c *current) number() (ast.NumberAttribute, error) {
 	return ast.NewNumberAttribute("", f), nil
 }
 
-func (c *current) array(attributes1, footerComment1 interface{}) (ast.ArrayAttribute, error) {
+func (c *current) array(attributes1, footerComment1 any) (ast.ArrayAttribute, error) {
 	var attributes []ast.Attribute
 	if attributes1 != nil {
 		attributes = attributes1.([]ast.Attribute)
@@ -323,7 +323,7 @@ func (c *current) array(attributes1, footerComment1 interface{}) (ast.ArrayAttri
 	return a, nil
 }
 
-func (c *current) hash(attributes1, footerComment1 interface{}) (ast.HashAttribute, error) {
+func (c *current) hash(attributes1, footerComment1 any) (ast.HashAttribute, error) {
 	var hashentries []ast.HashEntry
 	if attributes1 != nil {
 		hashentries = attributes1.([]ast.HashEntry)
@@ -336,7 +336,7 @@ func (c *current) hash(attributes1, footerComment1 interface{}) (ast.HashAttribu
 	return a, nil
 }
 
-func (c *current) hashentries(attribute, attributes1 interface{}) ([]ast.HashEntry, error) {
+func (c *current) hashentries(attribute, attributes1 any) ([]ast.HashEntry, error) {
 	entry := attribute.(ast.HashEntry)
 	if len(entry.Comment) > 0 {
 		entry.Comment[0].SpaceBefore = false
@@ -358,7 +358,7 @@ func (c *current) hashentries(attribute, attributes1 interface{}) ([]ast.HashEnt
 	return attributes, nil
 }
 
-func (c *current) hashentry(name, value, comment interface{}) (ast.HashEntry, error) {
+func (c *current) hashentry(name, value, comment any) (ast.HashEntry, error) {
 	key := name.(ast.HashEntryKey)
 
 	he := ast.NewHashEntry(key, value.(ast.Attribute))
@@ -368,19 +368,19 @@ func (c *current) hashentry(name, value, comment interface{}) (ast.HashEntry, er
 	return he, nil
 }
 
-func (c *current) elseIfComment(eib1, eibComment1 interface{}) (ast.ElseIfBlock, error) {
+func (c *current) elseIfComment(eib1, eibComment1 any) (ast.ElseIfBlock, error) {
 	eib := eib1.(ast.ElseIfBlock)
 	eib.Comment = c.commentBlock(eibComment1, false, false)
 	return eib, nil
 }
 
-func (c *current) elseComment(eb1, ebComment1 interface{}) (ast.ElseBlock, error) {
+func (c *current) elseComment(eb1, ebComment1 any) (ast.ElseBlock, error) {
 	eb := eb1.(ast.ElseBlock)
 	eb.Comment = c.commentBlock(ebComment1, false, false)
 	return eb, nil
 }
 
-func (c *current) branch(ifBlock1, elseIfBlocks1, elseBlock1, ifComment interface{}) (ast.Branch, error) {
+func (c *current) branch(ifBlock1, elseIfBlocks1, elseBlock1, ifComment any) (ast.Branch, error) {
 	ielseIfBlocks := toIfaceSlice(elseIfBlocks1)
 
 	var elseIfBlocks []ast.ElseIfBlock
@@ -403,7 +403,7 @@ func (c *current) branch(ifBlock1, elseIfBlocks1, elseBlock1, ifComment interfac
 	return ast.NewBranch(ifBlock, elseBlock, elseIfBlocks...), nil
 }
 
-func (c *current) branchOrPluginComment(bop1, comment1 interface{}) (ast.BranchOrPlugin, error) {
+func (c *current) branchOrPluginComment(bop1, comment1 any) (ast.BranchOrPlugin, error) {
 	var eop ast.BranchOrPlugin
 	switch t := bop1.(type) {
 	case ast.Plugin:
@@ -419,28 +419,28 @@ func (c *current) branchOrPluginComment(bop1, comment1 interface{}) (ast.BranchO
 	return eop, nil
 }
 
-func (c *current) ifBlock(cond, bops, comment1 interface{}) (ast.IfBlock, error) {
+func (c *current) ifBlock(cond, bops, comment1 any) (ast.IfBlock, error) {
 	ib := ast.NewIfBlock(cond.(ast.Condition), c.branchOrPlugins(bops)...)
 	ib.Start = c.astPos()
 	ib.FooterComment = c.commentBlock(comment1, false, false)
 	return ib, nil
 }
 
-func (c *current) elseIfBlock(cond, bops, comment1 interface{}) (ast.ElseIfBlock, error) {
+func (c *current) elseIfBlock(cond, bops, comment1 any) (ast.ElseIfBlock, error) {
 	eib := ast.NewElseIfBlock(cond.(ast.Condition), c.branchOrPlugins(bops)...)
 	eib.Start = c.astPos()
 	eib.FooterComment = c.commentBlock(comment1, false, false)
 	return eib, nil
 }
 
-func (c *current) elseBlock(bops, comment1 interface{}) (ast.ElseBlock, error) {
+func (c *current) elseBlock(bops, comment1 any) (ast.ElseBlock, error) {
 	eb := ast.NewElseBlock(c.branchOrPlugins(bops)...)
 	eb.Start = c.astPos()
 	eb.FooterComment = c.commentBlock(comment1, false, false)
 	return eb, nil
 }
 
-func (c *current) branchOrPlugins(bops1 interface{}) []ast.BranchOrPlugin {
+func (c *current) branchOrPlugins(bops1 any) []ast.BranchOrPlugin {
 	bops := toIfaceSlice(bops1)
 
 	var branchOrPlugins []ast.BranchOrPlugin
@@ -455,7 +455,7 @@ func (c *current) branchOrPlugins(bops1 interface{}) []ast.BranchOrPlugin {
 	return branchOrPlugins
 }
 
-func (c *current) condition(expr, exprs interface{}) (ast.Condition, error) {
+func (c *current) condition(expr, exprs any) (ast.Condition, error) {
 	iexprs := toIfaceSlice(expr)
 	iexprs = append(iexprs, toIfaceSlice(exprs)...)
 
@@ -471,55 +471,55 @@ func (c *current) condition(expr, exprs interface{}) (ast.Condition, error) {
 	return ast.NewCondition(expressions...), nil
 }
 
-func (c *current) expression(bo, expr1 interface{}) (ast.Expression, error) {
+func (c *current) expression(bo, expr1 any) (ast.Expression, error) {
 	expr := expr1.(ast.Expression)
 	expr.SetBoolOperator(bo.(ast.BooleanOperator))
 	return expr, nil
 }
 
-func (c *current) conditionExpression(cond interface{}) (ast.ConditionExpression, error) {
+func (c *current) conditionExpression(cond any) (ast.ConditionExpression, error) {
 	ce := ast.NewConditionExpression(ast.BooleanOperator{Op: ast.NoOperator}, cond.(ast.Condition))
 	ce.Start = c.astPos()
 	return ce, nil
 }
 
-func (c *current) negativeExpression(cond interface{}) (ast.NegativeConditionExpression, error) {
+func (c *current) negativeExpression(cond any) (ast.NegativeConditionExpression, error) {
 	ne := ast.NewNegativeConditionExpression(ast.BooleanOperator{Op: ast.NoOperator}, cond.(ast.Condition))
 	ne.Start = c.astPos()
 	return ne, nil
 }
 
-func (c *current) negativeSelector(sel interface{}) (ast.NegativeSelectorExpression, error) {
+func (c *current) negativeSelector(sel any) (ast.NegativeSelectorExpression, error) {
 	ns := ast.NewNegativeSelectorExpression(ast.BooleanOperator{Op: ast.NoOperator}, sel.(ast.Selector))
 	ns.Start = c.astPos()
 	return ns, nil
 }
 
-func (c *current) inExpression(lv, rv interface{}) (ast.InExpression, error) {
+func (c *current) inExpression(lv, rv any) (ast.InExpression, error) {
 	ie := ast.NewInExpression(ast.BooleanOperator{Op: ast.NoOperator}, lv.(ast.Rvalue), rv.(ast.Rvalue))
 	ie.Start = c.astPos()
 	return ie, nil
 }
 
-func (c *current) notInExpression(lv, rv interface{}) (ast.NotInExpression, error) {
+func (c *current) notInExpression(lv, rv any) (ast.NotInExpression, error) {
 	nie := ast.NewNotInExpression(ast.BooleanOperator{Op: ast.NoOperator}, lv.(ast.Rvalue), rv.(ast.Rvalue))
 	nie.Start = c.astPos()
 	return nie, nil
 }
 
-func (c *current) compareExpression(lv, co, rv interface{}) (ast.CompareExpression, error) {
+func (c *current) compareExpression(lv, co, rv any) (ast.CompareExpression, error) {
 	ce := ast.NewCompareExpression(ast.BooleanOperator{Op: ast.NoOperator}, lv.(ast.Rvalue), co.(ast.CompareOperator), rv.(ast.Rvalue))
 	ce.Start = c.astPos()
 	return ce, nil
 }
 
-func (c *current) regexpExpression(lv, ro, rv interface{}) (ast.RegexpExpression, error) {
+func (c *current) regexpExpression(lv, ro, rv any) (ast.RegexpExpression, error) {
 	re := ast.NewRegexpExpression(ast.BooleanOperator{Op: ast.NoOperator}, lv.(ast.Rvalue), ro.(ast.RegexpOperator), rv.(ast.StringOrRegexp))
 	re.Start = c.astPos()
 	return re, nil
 }
 
-func (c *current) rvalue(rv interface{}) (ast.RvalueExpression, error) {
+func (c *current) rvalue(rv any) (ast.RvalueExpression, error) {
 	re := ast.NewRvalueExpression(ast.BooleanOperator{Op: ast.NoOperator}, rv.(ast.Rvalue))
 	re.Start = c.astPos()
 	return re, nil
@@ -612,7 +612,7 @@ func (c *current) booleanOperator() (ast.BooleanOperator, error) {
 	}, nil
 }
 
-func (c *current) selector(ses1 interface{}) (ast.Selector, error) {
+func (c *current) selector(ses1 any) (ast.Selector, error) {
 	ises := toIfaceSlice(ses1)
 
 	var ses []ast.SelectorElement
@@ -648,15 +648,15 @@ func (c *current) astPos() ast.Pos {
 	return p
 }
 
-func toIfaceSlice(v interface{}) []interface{} {
+func toIfaceSlice(v any) []any {
 	if v == nil {
 		return nil
 	}
 	switch v1 := v.(type) {
-	case []interface{}:
+	case []any:
 		return v1
-	case interface{}:
-		return []interface{}{v1}
+	case any:
+		return []any{v1}
 	default:
 		return nil
 	}

--- a/logstash_config_pos_test.go
+++ b/logstash_config_pos_test.go
@@ -996,7 +996,7 @@ output {
 	}
 }
 
-func T(in interface{}) string {
+func T(in any) string {
 	return fmt.Sprintf("%T", in)
 }
 

--- a/logstash_config_test.go
+++ b/logstash_config_test.go
@@ -2,8 +2,8 @@ package config_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -413,7 +413,7 @@ func TestParserIdenticFile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Expected %q to parse without error: %v", test, err)
 			}
-			expected, err := ioutil.ReadFile(inputFilename)
+			expected, err := os.ReadFile(inputFilename)
 			if err != nil {
 				t.Fatalf("Unable to read file %q: %v", inputFilename, err)
 			}
@@ -686,7 +686,7 @@ func TestParserFile(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Expected %q to parse without error: %v", test, err)
 			}
-			expected, err := ioutil.ReadFile(expectedFilename)
+			expected, err := os.ReadFile(expectedFilename)
 			if err != nil {
 				t.Fatalf("Unable to read file %q: %v", expectedFilename, err)
 			}
@@ -953,7 +953,7 @@ func TestParseExceptionalComments(t *testing.T) {
 				t.Fatalf("Expected to parse to Config")
 			}
 
-			body, err := ioutil.ReadFile(inputFilename)
+			body, err := os.ReadFile(inputFilename)
 			if err != nil {
 				t.Fatalf("Unable to read file %q: %v", inputFilename, err)
 			}
@@ -984,7 +984,7 @@ func TestParseIgnoreComments(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Expected %q to parse without error: %v", test, err)
 			}
-			expected, err := ioutil.ReadFile(expectedFilename)
+			expected, err := os.ReadFile(expectedFilename)
 			if err != nil {
 				t.Fatalf("Unable to read file %q: %v", expectedFilename, err)
 			}


### PR DESCRIPTION
In this PR, we bump the golang version to 1.26 and we ran go fix to modernize the code. Contextually some ad-hoc functions were removed (e.g., Contains -> slices.Contains, pointer -> new).

WIP #3 